### PR TITLE
Remove furigana annotations from japanese queries

### DIFF
--- a/src/Forvo.py
+++ b/src/Forvo.py
@@ -51,12 +51,20 @@ class Pronunciation:
         self.audio = None
 
 
-def prepare_query_string(input: str, config: Config) -> str:
+def prepare_query_string(input: str, language: str, config: Config) -> str:
     query = str(input)  # clone
     query = query.strip()
     for char in config.get_config_object("replaceCharacters").value:
         query = query.replace(char, "")
+    query = remove_language_specific_annotations_from_query_string(input, language)
     log_debug("[Forvo.py] Using search query: %s" % query)
+    return query
+
+
+def remove_language_specific_annotations_from_query_string(query: str, language: str):
+    if language == "ja":
+        # remove furigana annotation from japanese query
+        query = re.sub(r"\[[^\]]*\]", "", query)
     return query
 
 
@@ -64,7 +72,7 @@ class Forvo:
     def __init__(self, word: str, language: str, mw, config: Config):
         self.html: BeautifulSoup
         self.language = language
-        self.word = prepare_query_string(word, config)
+        self.word = prepare_query_string(word, language, config)
         self.pronunciations: List[Pronunciation] = []
         self.mw = mw
 

--- a/src/Forvo.py
+++ b/src/Forvo.py
@@ -65,6 +65,9 @@ def remove_language_specific_annotations_from_query_string(query: str, language:
     if language == "ja":
         # remove furigana annotation from japanese query
         query = re.sub(r"\[[^\]]*\]", "", query)
+        # remove spaces because they're usually not a thing in japanese
+        # and are often used in the furigana annotation to separate words
+        query = re.sub(r"\s", "", query)
     return query
 
 


### PR DESCRIPTION
Hey,

a small change that removes a little annoyance from this plugin I've had for a while. 

## Reasoning

My query field usually looks something like this: 

> 日本語[にほんご]

(notice the [, ])

this is an Anki specific annotation (used in combination with the {{furigana:Front}} viewhelper) to render the text inside the brackets above the text before that, looks like this:

![image](https://user-images.githubusercontent.com/674705/163685817-45fe0ad0-3fee-4f14-bdc3-3480c5a77096.png)

which is used to provide the reading for the characters on the bottom. Obviously Forvo doesn't ignore this by default (and also does not contain entries using this syntax) meaning you have to either keep a separate query field or (what I and probably many others do) remove the annotation from the search field, hit the button for this addon, select the desired audio snippet and re-add the annotation. 

Best regards.