### PR TITLE
Updated PyQt5 imports to PyQt6

### DIFF
--- a/src/About.py
+++ b/src/About.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QDialog, QLabel, QVBoxLayout
+from PyQt6.QtWidgets import QDialog, QLabel, QVBoxLayout
 
 
 class About(QDialog):

--- a/src/AddSingle.py
+++ b/src/AddSingle.py
@@ -1,9 +1,9 @@
 import os
 import anki
 from typing import List
-from PyQt5.QtWidgets import *
-from PyQt5.QtGui import *
-from PyQt5.QtCore import *
+from PyQt6.QtWidgets import *
+from PyQt6.QtGui import *
+from PyQt6.QtCore import *
 
 from .Forvo import Pronunciation
 from anki_forvo_dl.src.util.Util import CustomScrollbar

--- a/src/ConfigManager.py
+++ b/src/ConfigManager.py
@@ -2,8 +2,8 @@ import json
 import os
 
 import aqt
-from PyQt5 import QtCore
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLayout, QLineEdit, QComboBox, QCheckBox, QHBoxLayout, \
+from PyQt6 import QtCore
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QLayout, QLineEdit, QComboBox, QCheckBox, QHBoxLayout, \
     QScrollArea, QFrame
 
 from .Config import Config, ConfigObject, OptionType

--- a/src/FailedDownloadsDialog.py
+++ b/src/FailedDownloadsDialog.py
@@ -1,7 +1,7 @@
 from typing import List
-from PyQt5.QtCore import Qt, QUrl
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QAbstractScrollArea, \
+from PyQt6.QtCore import Qt, QUrl
+from PyQt6.QtGui import QDesktopServices
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QAbstractScrollArea, \
     QPushButton, QHBoxLayout, QWidget, QAbstractItemView
 from anki.cards import Card
 from aqt.browser import Browser

--- a/src/FieldSelector.py
+++ b/src/FieldSelector.py
@@ -1,5 +1,5 @@
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QLabel, QVBoxLayout, QDialog, QRadioButton, QPushButton, QButtonGroup
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QLabel, QVBoxLayout, QDialog, QRadioButton, QPushButton, QButtonGroup
 from aqt import AnkiQt
 
 from .Config import Config

--- a/src/GuiElements.py
+++ b/src/GuiElements.py
@@ -1,8 +1,8 @@
 from functools import partial
 
-from PyQt5.QtCore import QSize
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QLayout, QDialog, QPushButton, QVBoxLayout, QWidget, QHBoxLayout, QLineEdit, QLabel, \
+from PyQt6.QtCore import QSize
+from PyQt6.QtGui import QIcon
+from PyQt6.QtWidgets import QLayout, QDialog, QPushButton, QVBoxLayout, QWidget, QHBoxLayout, QLineEdit, QLabel, \
     QComboBox
 
 from .Config import ConfigObject

--- a/src/LanguageSelector.py
+++ b/src/LanguageSelector.py
@@ -1,8 +1,8 @@
 import json
 import os
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QComboBox, QPushButton
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QComboBox, QPushButton
 
 
 class LanguageSelector(QDialog):

--- a/src/WhatsNew.py
+++ b/src/WhatsNew.py
@@ -1,6 +1,6 @@
 import os
 from typing import Union
-from PyQt5.QtWidgets import QDialog, QLabel, QVBoxLayout, QLayout
+from PyQt6.QtWidgets import QDialog, QLabel, QVBoxLayout, QLayout
 
 from anki_forvo_dl.src.util.Util import parse_version
 

--- a/src/util/Util.py
+++ b/src/util/Util.py
@@ -3,7 +3,7 @@ import platform
 import subprocess
 from dataclasses import dataclass
 
-from PyQt5.QtWidgets import QScrollBar, QWidget
+from PyQt6.QtWidgets import QScrollBar, QWidget
 from anki.cards import Card
 from anki.notes import Note
 


### PR DESCRIPTION
Updated PyQt5 to PyQt6 so it is compatible with the latest Anki version 23.10. PyQt6 is imports are backwards compatible so simply changing all the import names fixes the startup error. Further optimization may be necessary.

fix for: #96 #97 