### PR TITLE
Add Qt6 compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -61,7 +61,7 @@ def add_pronunciation(editor: Editor, mode: Union[None, str] = None):
             """Choose top pronunciation automatically when shift key is held down"""
             mode = "auto"
 
-    deck_id = editor.card.did if editor.card is not None else editor.parentWindow.deckChooser.selectedId()
+    deck_id = editor.card.did if editor.card is not None else editor.parentWindow.deck_chooser.selectedId()
 
     if editor.note is not None:
         note_type_id = editor.note.mid

--- a/__init__.py
+++ b/__init__.py
@@ -174,7 +174,7 @@ def add_pronunciation(editor: Editor, mode: Union[None, str] = None):
 
                 def flush_field():
                     if not editor.addMode:  # save
-                        editor.note.flush()
+                        mw.col.update_note(editor.note)
                     editor.currentField = get_field_id(audio_field, editor.note)
                     editor.loadNote(focusTo=get_field_id(audio_field, editor.note))
 
@@ -209,7 +209,7 @@ def add_pronunciation(editor: Editor, mode: Union[None, str] = None):
                         "Couldn't find field '%s' for adding the audio string. Please create a field with this name or change it in the config for the note type id %s" % (
                             audio_field, str(note_type_id)), editor.widget)
                 if not editor.addMode:
-                    editor.note.flush()
+                    mw.col.update_note(editor.note)
                 editor.loadNote()
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -57,7 +57,7 @@ def handle_field_select(d, note_type_id, field_type, editor):
 def add_pronunciation(editor: Editor, mode: Union[None, str] = None):
     if mode is None:
         modifiers = QApplication.keyboardModifiers()
-        if modifiers == Qt.ShiftModifier:
+        if modifiers == Qt.KeyboardModifier.ShiftModifier:
             """Choose top pronunciation automatically when shift key is held down"""
             mode = "auto"
 

--- a/src/About.py
+++ b/src/About.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QDialog, QLabel, QVBoxLayout
+from aqt.qt import QDialog, QLabel, QVBoxLayout
 
 
 class About(QDialog):

--- a/src/AddSingle.py
+++ b/src/AddSingle.py
@@ -1,9 +1,10 @@
 import os
 import anki
 from typing import List
-from PyQt5.QtWidgets import *
-from PyQt5.QtGui import *
-from PyQt5.QtCore import *
+#from PyQt5.QtWidgets import *
+#from PyQt5.QtGui import *
+#from PyQt5.QtCore import *
+from aqt.qt import *
 
 from .Forvo import Pronunciation
 from anki_forvo_dl.src.util.Util import CustomScrollbar
@@ -77,7 +78,7 @@ class AddSingle(QDialog):
         if hidden_entries_amount > 0:
             self.description += f"<b><small>There are {hidden_entries_amount} more entries which you chose to hide by deactivating .ogg fallback.</small></b>"
         self.description_label = QLabel(text=self.description)
-        self.description_label.setAlignment(Qt.AlignCenter)
+        self.description_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.layout.addWidget(self.description_label)
 
         # Create the list

--- a/src/AddSingle.py
+++ b/src/AddSingle.py
@@ -100,9 +100,9 @@ class AddSingle(QDialog):
         pronunciation_list.setFixedWidth(480)
         pronunciation_list.setMinimumHeight(500)
         pronunciation_list.setVerticalScrollBar(CustomScrollbar())
-        pronunciation_list.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        pronunciation_list.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel)
-        pronunciation_list.setSelectionMode(QAbstractItemView.NoSelection)
+        pronunciation_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        pronunciation_list.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        pronunciation_list.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
         self.setMaximumHeight(1000)
 
         self.layout.addWidget(pronunciation_list)

--- a/src/AddSingle.py
+++ b/src/AddSingle.py
@@ -1,9 +1,6 @@
 import os
 import anki
 from typing import List
-#from PyQt5.QtWidgets import *
-#from PyQt5.QtGui import *
-#from PyQt5.QtCore import *
 from aqt.qt import *
 
 from .Forvo import Pronunciation

--- a/src/ConfigManager.py
+++ b/src/ConfigManager.py
@@ -2,8 +2,7 @@ import json
 import os
 
 import aqt
-from PyQt5 import QtCore
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLayout, QLineEdit, QComboBox, QCheckBox, QHBoxLayout, \
+from aqt.qt import Qt, QDialog, QVBoxLayout, QLabel, QLayout, QLineEdit, QComboBox, QCheckBox, QHBoxLayout, \
     QScrollArea, QFrame
 
 from .Config import Config, ConfigObject, OptionType
@@ -24,7 +23,7 @@ class ConfigManager(QDialog):
         self.setWindowTitle("Configure anki-forvo-dl")
 
         self.layout = QHBoxLayout()
-        self.layout.setAlignment(QtCore.Qt.AlignTop)
+        self.layout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.layout.setSpacing(20)
         self.setLayout(self.layout)
 
@@ -47,7 +46,7 @@ class ConfigManager(QDialog):
         general_frame.setContentsMargins(0, 0, 0, 0)
         self.general_col = QVBoxLayout(scrollarea)
         self.general_col.addWidget(label)
-        self.general_col.setAlignment(QtCore.Qt.AlignTop)
+        self.general_col.setAlignment(Qt.AlignmentFlag.AlignTop)
         general_frame.setLayout(self.general_col)
         scrollarea.setWidget(general_frame)
         scrollarea.setWidgetResizable(True)
@@ -72,7 +71,7 @@ class ConfigManager(QDialog):
         deck_frame = QFrame(deck_scrollarea)
         deck_frame.setContentsMargins(0, 0, 0, 0)
         self.deck_col = QVBoxLayout(deck_scrollarea)  # outer column that contains all deck-specific settings
-        self.deck_col.setAlignment(QtCore.Qt.AlignTop)
+        self.deck_col.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.deck_col.addWidget(label)
         deck_frame.setLayout(self.deck_col)
         deck_scrollarea.setWidget(deck_frame)
@@ -87,7 +86,7 @@ class ConfigManager(QDialog):
         selector.addWidget(label)
 
         self.inner_deck_col = QVBoxLayout()  # inner layout (within the deck_col layout) that contains the individual settings
-        self.inner_deck_col.setAlignment(QtCore.Qt.AlignTop)
+        self.inner_deck_col.setAlignment(Qt.AlignmentFlag.AlignTop)
 
         self.deck_selector = QComboBox()  # Actual dropdown
         self.deck_selector.currentIndexChanged.connect(lambda: self.draw_deck_elements())  # Connect events that fire on dropdown selection change
@@ -120,7 +119,7 @@ class ConfigManager(QDialog):
         nt_frame.setContentsMargins(0, 0, 0, 0)
         self.nt_col = QVBoxLayout(nt_scrollarea)  # outer column that contains all deck-specific settings
         self.nt_col = QVBoxLayout()  # outer column that contains all nt-specific settings
-        self.nt_col.setAlignment(QtCore.Qt.AlignTop)
+        self.nt_col.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.nt_col.addWidget(label)
         nt_frame.setLayout(self.nt_col)
         nt_scrollarea.setWidget(nt_frame)
@@ -135,7 +134,7 @@ class ConfigManager(QDialog):
         selector.addWidget(label)
 
         self.inner_nt_col = QVBoxLayout()  # inner layout (within the nt_col layout) that contains the individual settings
-        self.inner_nt_col.setAlignment(QtCore.Qt.AlignTop)
+        self.inner_nt_col.setAlignment(Qt.AlignmentFlag.AlignTop)
 
         self.nt_selector = QComboBox()  # Actual dropdown
         self.nt_selector.currentIndexChanged.connect(self.draw_nt_elements)  # Connect events that fire on dropdown selection change
@@ -155,9 +154,9 @@ class ConfigManager(QDialog):
         self.draw_nt_elements()
 
         # -----------------------------
-        self.layout.addWidget(scrollarea, alignment=QtCore.Qt.AlignLeft)  # add columns to horizontal layout
-        self.layout.addWidget(deck_scrollarea, alignment=QtCore.Qt.AlignLeft)
-        self.layout.addWidget(nt_scrollarea, alignment=QtCore.Qt.AlignLeft)
+        self.layout.addWidget(scrollarea, alignment=Qt.AlignmentFlag.AlignLeft)  # add columns to horizontal layout
+        self.layout.addWidget(deck_scrollarea, alignment=Qt.AlignmentFlag.AlignLeft)
+        self.layout.addWidget(nt_scrollarea, alignment=Qt.AlignmentFlag.AlignLeft)
         self.adjustSize()  # recalculate geometry so that everything fits into the window
 
 

--- a/src/FailedDownloadsDialog.py
+++ b/src/FailedDownloadsDialog.py
@@ -1,7 +1,5 @@
 from typing import List
-from PyQt5.QtCore import Qt, QUrl
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QAbstractScrollArea, \
+from aqt.qt import Qt, QUrl, QDesktopServices, QDialog, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QAbstractScrollArea, \
     QPushButton, QHBoxLayout, QWidget, QAbstractItemView
 from anki.cards import Card
 from aqt.browser import Browser
@@ -61,7 +59,7 @@ class FailedDownloadsDialog(QDialog):
         self.description_label.setMinimumSize(self.sizeHint())
         self.description_label.setMinimumHeight(100)
         self.description_label.setWordWrap(True)
-        self.description_label.setAlignment(Qt.AlignCenter)
+        self.description_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.layout.addWidget(self.description_label)
         self.show_reasons()
 

--- a/src/FieldSelector.py
+++ b/src/FieldSelector.py
@@ -1,5 +1,4 @@
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QLabel, QVBoxLayout, QDialog, QRadioButton, QPushButton, QButtonGroup
+from aqt.qt import Qt, QLabel, QVBoxLayout, QDialog, QRadioButton, QPushButton, QButtonGroup
 from aqt import AnkiQt
 
 from .Config import Config
@@ -20,7 +19,7 @@ class FieldSelector(QDialog):
         description_label = QLabel(description_header)
         description_label.setMinimumSize(self.sizeHint())
         description_label.setWordWrap(True)
-        description_label.setAlignment(Qt.AlignCenter)
+        description_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.layout.addWidget(description_label)
 

--- a/src/GuiElements.py
+++ b/src/GuiElements.py
@@ -1,8 +1,6 @@
 from functools import partial
 
-from PyQt5.QtCore import QSize
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QLayout, QDialog, QPushButton, QVBoxLayout, QWidget, QHBoxLayout, QLineEdit, QLabel, \
+from aqt.qt import QSize, QIcon, QLayout, QDialog, QPushButton, QVBoxLayout, QWidget, QHBoxLayout, QLineEdit, QLabel, \
     QComboBox
 
 from .Config import ConfigObject

--- a/src/LanguageSelector.py
+++ b/src/LanguageSelector.py
@@ -1,8 +1,7 @@
 import json
 import os
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QComboBox, QPushButton
+from aqt.qt import Qt, QDialog, QVBoxLayout, QLabel, QComboBox, QPushButton
 
 
 class LanguageSelector(QDialog):
@@ -20,7 +19,7 @@ class LanguageSelector(QDialog):
         description_label = QLabel(description)
         description_label.setMinimumSize(self.sizeHint())
         description_label.setWordWrap(True)
-        description_label.setAlignment(Qt.AlignCenter)
+        description_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.layout.addWidget(description_label)
 

--- a/src/WhatsNew.py
+++ b/src/WhatsNew.py
@@ -1,6 +1,6 @@
 import os
 from typing import Union
-from PyQt5.QtWidgets import QDialog, QLabel, QVBoxLayout, QLayout
+from aqt.qt import QDialog, QLabel, QVBoxLayout, QLayout
 
 from anki_forvo_dl.src.util.Util import parse_version
 
@@ -21,7 +21,7 @@ class WhatsNew(QDialog):
         self.description_l.adjustSize()
         self.description_l.setFixedHeight(self.description_l.height())
         self.layout.addWidget(self.description_l)
-        self.layout.setSizeConstraint(QLayout.SetFixedSize)
+        self.layout.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
         self.adjustSize()
 
 

--- a/src/util/Util.py
+++ b/src/util/Util.py
@@ -3,7 +3,7 @@ import platform
 import subprocess
 from dataclasses import dataclass
 
-from PyQt5.QtWidgets import QScrollBar, QWidget
+from aqt.qt import QScrollBar
 from anki.cards import Card
 from anki.notes import Note
 


### PR DESCRIPTION
Publishing this PR to replace #98 since it hasn't been updated yet.

Follows the guidance in https://forums.ankiweb.net/t/porting-tips-for-anki-23-10/35916 to update the addon to be compatible with Qt6 versions of Anki after 23.10. The following changes are necessary for this:
* Import from `aqt.qt` instead of `PyQt5`
* Preface enum values with their type names

This PR also updates a few usages of deprecated functions and variables.

I tested the following functionality on both Qt5 and Qt6 builds of Anki 23.12.1:

* Selecting fields and language for new deck
* Adding audio to new card using both the editor button and Ctrl-F keyboard shortcut
* Adding audio to an existing card using the editor button
* Changing preferences using the addon preferences window

Fixes #96, #97, #99