### PR TITLE
Fix uncaught exception, only a single pronunciation ever found

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@ from .src.About import About
 from .src.AddSingle import AddSingle
 from .src.Config import Config, ConfigObject, OptionType
 from .src.ConfigManager import ConfigManager
-from .src.Exceptions import FieldNotFoundException
+from .src.Exceptions import FieldNotFoundException, NoResultsException
 from .src.FieldSelector import FieldSelector
 from .src.Forvo import Forvo, Pronunciation
 from .src.LanguageSelector import LanguageSelector
@@ -56,9 +56,11 @@ def handle_field_select(d, note_type_id, field_type, editor):
 
 
 def on_fetch_success(forvo: Forvo, editor: Editor, note: Note, mode: str, audio_field: str, note_type_id: int):
-    if forvo is not None:
+    try:
+        if forvo is None:
+            raise NoResultsException()
         results = forvo.get_pronunciations().pronunciations
-    else:
+    except NoResultsException:
         showInfo("No results found! :(", editor.widget)
         return
 

--- a/src/Forvo.py
+++ b/src/Forvo.py
@@ -153,18 +153,18 @@ class Forvo:
                     for k, v in link.attrs.items()
                     if re.match(r"^data-p\d+$", k) and re.match(r"^\d+$", v)
                 }))
-            if id_:
-                self.pronunciations.append(
-                    Pronunciation(self.language,
-                                  username,
-                                  pronunciation.find_all(class_="from")[0].contents[0],
-                                  id_,
-                                  vote_count,
-                                  dl_url,
-                                  is_ogg,
-                                  self.word,
-                                  self.media
-                                  ))
+                if id_:
+                    self.pronunciations.append(
+                        Pronunciation(self.language,
+                                    username,
+                                    pronunciation.find_all(class_="from")[0].contents[0],
+                                    id_,
+                                    vote_count,
+                                    dl_url,
+                                    is_ogg,
+                                    self.word,
+                                    self.media
+                                    ))
 
         return self
 


### PR DESCRIPTION
This PR fixes two bugs:

1. The "Anki encountered a problem" dialog was being shown due to an uncaught exception and shown when a translation page had results, but none in the target language.

2. Only a single pronunciation was only ever being found, due to incorrect indentation (probably because of a bad merge).
