### PR TITLE
Fix empty error message thrown upon 404 pages

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -215,7 +215,13 @@ def add_pronunciation(editor: Editor, mode: Union[None, str] = None):
         else:
             language = config_lang.value
 
-        op = QueryOp(parent=editor.mw, op=lambda x: Forvo(query, language, editor.mw.col.media, config).load_search_query(), success=lambda forvo: on_fetch_success(forvo, editor, editor.note, mode, audio_field, note_type_id))
+        def search_query(x):
+            try:
+                return Forvo(query, language, editor.mw.col.media, config).load_search_query()
+            except NoResultsException:
+                return None
+
+        op = QueryOp(parent=editor.mw, op=search_query, success=lambda forvo: on_fetch_success(forvo, editor, editor.note, mode, audio_field, note_type_id))
         op.run_in_background()
 
 

--- a/src/Exceptions.py
+++ b/src/Exceptions.py
@@ -1,9 +1,17 @@
-class NoResultsException(Exception):
+class AnkiForvoException(Exception):
+    friendly = "AnkiForvoException"
+    info = "An exception occurred in the anki-forvo-dl add-on."
+
+    def __str__(self):
+        return self.friendly + ": " + self.info
+
+
+class NoResultsException(AnkiForvoException):
     friendly = "No results found"
     info = "No pronunciations were found on Forvo for the cards."
 
 
-class FieldNotFoundException(Exception):
+class FieldNotFoundException(AnkiForvoException):
     friendly = "Field not found"
     info = "A field couldn't be found."
 
@@ -12,7 +20,7 @@ class FieldNotFoundException(Exception):
         self.specific_info = "'%s'" % field_name
 
 
-class DownloadCancelledException(Exception):
+class DownloadCancelledException(AnkiForvoException):
     friendly = "Download cancelled"
     info = "These pronunciations couldn't be downloaded because the download was cancelled."
 


### PR DESCRIPTION
This fixes an empty message box shown when search results return a 404.

When Anki encounters an uncaught custom exception, it uses the `__str__` method to determine the error message. Since these exceptions didn’t have `__str__` defined, the error message was empty. I also added a new exception superclass, `AnkiForvoException` to help debug this in the future.

Fixes #106